### PR TITLE
Add PHPStan & Fix existing errors (no backwards-compatibility breaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ foreach ($domains as $domain) {
 }
 ```
 
+## Contributing
+
+When contributing to this project, you can run the following quality checks:
+
+```bash
+$ vendor/bin/phpstan
+```
+
 ## License
 
 The MIT License (MIT)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "php-http/mock-client": "^1.4",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.81",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.5",
         "monolog/monolog": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "guzzlehttp/psr7": "^1.7",
         "psr/log": "^1.1",
         "spatie/enum": "^3.6",
-        "guzzlehttp/guzzle": ">=6"
+        "guzzlehttp/guzzle": ">=6",
+        "illuminate/pagination": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 0
+	paths:
+		- src

--- a/src/Managers/FolderManager.php
+++ b/src/Managers/FolderManager.php
@@ -29,7 +29,7 @@ class FolderManager extends AbstractManager implements FolderManagerInterface, L
      *
      * @param int $page
      * @param int $perPage
-     * @param array $filters
+     * @param array|null $filters
      * @return \DnsMadeEasy\Pagination\Paginator|mixed
      * @throws \DnsMadeEasy\Exceptions\Client\Http\HttpException
      * @throws \ReflectionException

--- a/src/Managers/FolderManager.php
+++ b/src/Managers/FolderManager.php
@@ -29,10 +29,12 @@ class FolderManager extends AbstractManager implements FolderManagerInterface, L
      *
      * @param int $page
      * @param int $perPage
+     * @param array $filters
      * @return \DnsMadeEasy\Pagination\Paginator|mixed
+     * @throws \DnsMadeEasy\Exceptions\Client\Http\HttpException
      * @throws \ReflectionException
      */
-    public function paginate(int $page = 1, int $perPage = 20)
+    public function paginate(int $page = 1, int $perPage = 20, $filters = [])
     {
         $response = $this->client->get($this->getBaseUri());
         $data = json_decode((string)$response->getBody());


### PR DESCRIPTION
I have added PHPStan to this project with a config on `level 0` (very lenient).

I have also updated the README with instructions on how to use this.

While running level 0, I found two issues:
* `src/Managers/FolderManager.php` did not adhere to its interface.
* `illuminate/pagination` is a dependency that was not included in the package.

Both of these issues have also been fixed. I have checked the implementation that is used for `illuminate/pagination` and I have added all version constraints that are compatible with the implementation.