### PR TITLE
Added 6.2.0 to guzzle composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "guzzlehttp/psr7": "^1.7",
         "psr/log": "^1.1",
         "spatie/enum": "^3.6",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^6.2.0|^7.0",
         "illuminate/pagination": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
We went on  pr #5 from their setup guzzle 6 to 7 so I added it back.
We also need  guzzle 6.2 for our WaterFront application.