### PR TITLE
Support for Guzzle 6.x alongside 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "guzzlehttp/psr7": "^1.4.2|^1.7",
         "psr/log": "^1.1",
         "spatie/enum": "^3.6",
-        "guzzlehttp/guzzle": "^6.2.0",
+        "guzzlehttp/guzzle": "^6.2.0|^7.0",
         "illuminate/pagination": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,10 @@
         "php": "^7.4|^8.0",
         "ext-mbstring": "*",
         "psr/container": "^1.0",
-        "psr/http-client-implementation": "^1.0",
         "guzzlehttp/psr7": "^1.4.2|^1.7",
         "psr/log": "^1.1",
         "spatie/enum": "^3.6",
-        "guzzlehttp/guzzle": "^6.2.0|^7.0",
+        "guzzlehttp/guzzle": "^6.2.0",
         "illuminate/pagination": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -16,7 +16,7 @@ use DnsMadeEasy\Interfaces\Managers\TemplateManagerInterface;
 use DnsMadeEasy\Interfaces\Managers\TransferAclManagerInterface;
 use DnsMadeEasy\Interfaces\Managers\UsageManagerInterface;
 use DnsMadeEasy\Interfaces\Managers\VanityNameServerManagerInterface;
-use Psr\Http\Client\ClientInterface as HttpClientInterface;
+use GuzzleHttp\Client;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -42,18 +42,18 @@ interface ClientInterface
     /**
      * Set a custom HTTP Client for all requests. If one is not provided, one is created automatically.
      *
-     * @param HttpClientInterface $client
+     * @param Client $client
      *
      * @return ClientInterface
      */
-    public function setHttpClient(HttpClientInterface $client): ClientInterface;
+    public function setHttpClient(Client $client): ClientInterface;
 
     /**
      * Fetches the current HTTP Client used for requests.
      *
-     * @return HttpClientInterface
+     * @return Client
      */
-    public function getHttpClient(): HttpClientInterface;
+    public function getHttpClient(): Client;
 
     /**
      * Set the API endpoint to use. By default this is `https://api.dnsmadeeasy.com/V2.0`. You can set this to


### PR DESCRIPTION
In order to support 6.x, we cannot typehint on the Psr HttpInterface. We have to depend on the Guzzle/Client directly instead.